### PR TITLE
fix: publish permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,14 +17,14 @@ jobs:
         node-version: [ 20.x, 22.x ]
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
     - name: Use Node ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
         cache: npm
-
-    - name: Checkout repository
-      uses: actions/checkout@v4
 
     - name: Clean install
       run: npm ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,7 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
+        cache: npm
 
     - name: Checkout repository
       uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,12 +38,16 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
-      - name: Setup .npmrc file to publish to npm
+      - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: '22'
+          cache: npm
       - name: Install modules
         run: npm ci
       - name: Build


### PR DESCRIPTION
- #5 failed publishing [failed](https://github.com/curvefi/ethcall/actions/runs/13152939612)
- According to the documentation [you should set the permissions for this access token in the workflow file to grant read access for the contents permission and write access for the packages permission](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#authenticating-to-the-destination-repository)
- I also added caching for the CI job